### PR TITLE
Initialize React Native math learning app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Node
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Expo
+.expo/
+.expo-shared/
+
+# React Native
+android/build/
+ios/build/
+*.apk
+*.aab
+
+# Others
+.DS_Store
+.idea/
+.vscode/

--- a/App.js
+++ b/App.js
@@ -1,0 +1,79 @@
+import React, { useState, useEffect } from 'react';
+import { StyleSheet, Text, View, TextInput, Button } from 'react-native';
+import { StatusBar } from 'expo-status-bar';
+
+export default function App() {
+  const [question, setQuestion] = useState({ a: 0, b: 0, op: '+', answer: 0 });
+  const [input, setInput] = useState('');
+  const [feedback, setFeedback] = useState('');
+
+  const generateQuestion = () => {
+    const a = Math.floor(Math.random() * 11); // 0-10
+    const b = Math.floor(Math.random() * 11);
+    const op = Math.random() < 0.5 ? '+' : '-';
+    let first = a;
+    let second = b;
+    if (op === '-' && b > a) {
+      first = b;
+      second = a;
+    }
+    const ans = op === '+' ? first + second : first - second;
+    setQuestion({ a: first, b: second, op, answer: ans });
+    setInput('');
+    setFeedback('');
+  };
+
+  useEffect(() => {
+    generateQuestion();
+  }, []);
+
+  const checkAnswer = () => {
+    if (parseInt(input, 10) === question.answer) {
+      setFeedback('Great job!');
+      generateQuestion();
+    } else {
+      setFeedback('Try again!');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.question}>{`${question.a} ${question.op} ${question.b} = ?`}</Text>
+      <TextInput
+        style={styles.input}
+        value={input}
+        onChangeText={setInput}
+        keyboardType="numeric"
+      />
+      <Button title="Check" onPress={checkAnswer} />
+      <Text style={styles.feedback}>{feedback}</Text>
+      <StatusBar style="auto" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  question: {
+    fontSize: 32,
+    marginBottom: 20,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#000',
+    width: 80,
+    fontSize: 24,
+    textAlign: 'center',
+    marginBottom: 10,
+  },
+  feedback: {
+    fontSize: 24,
+    marginTop: 10,
+    height: 30,
+  },
+});

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Kids Learn Math
+
+A simple React Native application for Android that helps children (ages 4-7) practice basic addition and subtraction.
+
+## Features
+
+- Randomly generates addition or subtraction questions using numbers from 0 to 10.
+- Ensures subtraction never results in a negative number.
+- Provides immediate feedback and generates a new question after a correct answer.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm start
+   ```
+3. Run on an Android device or emulator:
+   ```bash
+   npm run android
+   ```
+
+## Building an APK
+
+This project uses [Expo](https://expo.dev/). To create an Android APK:
+
+```bash
+npm install -g eas-cli
+npx eas build -p android --profile preview
+```
+
+Follow the EAS CLI prompts to complete the build process.
+
+## Testing
+
+This project currently has no automated tests. Running `npm test` will simply print a message.
+
+## License
+
+This project is released under the terms of the [MIT License](LICENSE).

--- a/app.json
+++ b/app.json
@@ -6,8 +6,14 @@
     "orientation": "portrait",
     "userInterfaceStyle": "light",
     "assetBundlePatterns": ["**/*"],
+    "splash": {
+      "backgroundColor": "#ffffff"
+    },
     "android": {
-      "package": "com.example.kidslearnmath"
+      "package": "com.example.kidslearnmath",
+      "splash": {
+        "backgroundColor": "#ffffff"
+      }
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -1,0 +1,13 @@
+{
+  "expo": {
+    "name": "Kids Learn Math",
+    "slug": "kids-learn-math",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "userInterfaceStyle": "light",
+    "assetBundlePatterns": ["**/*"],
+    "android": {
+      "package": "com.example.kidslearnmath"
+    }
+  }
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "kids-learn-math",
+  "version": "1.0.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "test": "echo \"No tests\" && exit 0"
+  },
+  "dependencies": {
+    "expo": "^51.0.0",
+    "expo-status-bar": "~1.11.1",
+    "react": "18.2.0",
+    "react-native": "0.74.1"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.24.0",
+    "babel-preset-expo": "^9.5.0"
+  },
+  "private": true
+}


### PR DESCRIPTION
## Summary
- scaffold Expo-based React Native project
- implement basic addition/subtraction quiz for kids
- document setup and Android APK build instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adc6bd80248324a643f3c376c7184f