### PR TITLE
chore: make repo AI-ready and clean up dead code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,150 +1,111 @@
-# Agent Instructions - Kids Learn Math
+# Agent Instructions — Kids Learn Math
 
-This document provides guidance for AI assistants (LLMs) working with this codebase.
+Guidance for AI coding assistants working on this repository.
 
-## App Architecture
+## What this app is
 
-### Technology Stack
-- **Framework**: Bare React Native 0.74.1 (no Expo)
-- **Language**: JavaScript (ES6+)
-- **Platform**: Android (primary), iOS support can be added
-- **JS Engine**: Hermes (enabled for performance)
-- **Build System**: Gradle 8.3
-- **Bundle**: Metro bundler
+An offline, multilingual React Native app for children aged 6–10 that teaches addition, subtraction, and logical thinking through visual learning modules and minigames. Pedagogy is inspired by Soviet math curricula (Moró, Peterson, Kolmogorov). See `requirements/prd.md` and `requirements/1. MVP.md` for the product spec.
 
-### Project Structure
+The MVP is implemented (Phase 1 per `README.md`). Visual assets are placeholders (emoji); custom art and audio are planned but not yet in the repo.
+
+## Stack
+
+- React Native **0.74.1** (bare workflow — **no Expo**)
+- JavaScript (ES6+), functional components + hooks only
+- **React Navigation 6** (`@react-navigation/stack`)
+- **React Context** for state (no Redux/MobX)
+- **AsyncStorage** for persistence
+- **i18n-js** + **react-native-localize** for EN/RU/ES
+- **react-native-reanimated** (plugin configured; animations minimal in MVP)
+- Android is the primary platform; iOS is not wired up
+
+## Project layout
 
 ```
-kids-learn-math/
-├── android/              # Native Android project (Gradle, Java)
-├── assets/              # Static assets (images)
-├── App.js               # Main application component
-├── index.js             # App entry point (AppRegistry)
-├── package.json         # Dependencies and scripts
-├── metro.config.js      # Metro bundler configuration
-└── babel.config.js      # Babel transpilation config
+App.js                    Root — wraps providers and AppNavigator
+index.js                  RN entry point (AppRegistry)
+app.json                  RN app name
+requirements/             PRD + MVP spec (source of truth for product)
+assets/                   Static images (currently just professor-corgi.jpeg)
+android/                  Native Android project
+src/
+  navigation/AppNavigator.js     Stack navigator — all screens registered here
+  contexts/                      State — SettingsContext, ProgressContext, RewardContext
+  screens/
+    WelcomeScreen.js             Entry + session start
+    MainMenuScreen.js            Hub (learn / play / progress / settings)
+    ProgressScreen.js            Tree of Reason + stats
+    SettingsScreen.js            Language, audio toggles, a11y toggles
+    learning/                    AdditionVisual, SubtractionVisual, StoryProblems
+    games/                       NumberLabyrinth, FindPair, LostNumbers
+  components/common/             Button, Card (shared UI primitives)
+  utils/
+    constants.js                 COLORS, DIFFICULTY_LEVELS, GAME_CONFIG, TREE_STAGES, etc.
+    i18n.js                      i18n instance + t() helper
+    storage.js                   AsyncStorage read/write helpers
+    questionGenerator.js         Pure functions that produce questions/pairs/sequences
+  locales/                       en.json, ru.json, es.json
 ```
 
-## Code Patterns & Conventions
+## State
 
-### State Management
-- **Current**: React hooks (`useState`, `useEffect`)
-- **Pattern**: Functional components only
-- **No external state library** (Redux, MobX, etc.)
+Three context providers, mounted in `App.js`:
 
-### Component Structure
-- Single main component in `App.js`
-- Uses React Native core components: `View`, `Text`, `TextInput`, `Button`, `ImageBackground`, `StatusBar`
-- StyleSheet API for styling (no styled-components)
+- **SettingsContext** — `language`, `settings` (music/sound/voice/high contrast/large text/reduced motion), `changeLanguage`, `toggleSetting`
+- **ProgressContext** — lessons/games completed, `skillsTracked`, `attemptHistory`, `bestStreak`, methods: `completeLesson`, `completeGame`, `recordAttempt`, `startSession`, `unlockAchievement`, `getStats`
+- **RewardContext** — `treeState` (leaves/sparks/flowers/stage/unlockedZones), `addLeaves`, `addSparks`, `unlockZone`, `getGrowthProgress`
 
-### Business Logic
-- Math question generation: Random integers 0-10
-- Operations: Addition (+) and Subtraction (-)
-- Subtraction constraint: Always positive results (larger number first)
-- Immediate feedback on answer submission
+All three auto-hydrate from AsyncStorage on mount and persist on every update. Keys live in `STORAGE_KEYS` (`src/utils/constants.js`).
 
-### Styling Approach
-- **Color palette** defined at top of component
-- **StyleSheet.create()** for all styles
-- **Semi-transparent overlay** for content readability over background image
-- **No external styling libraries** (no NativeWind, Tailwind, etc.)
+## Conventions
 
-## Development Guidelines
+- **Functional components + hooks only.** No class components.
+- **Styling:** `StyleSheet.create` per-screen. Shared sizing/colors/typography come from `src/utils/constants.js` — prefer these over raw values.
+- **Text must go through `t()`** from `src/utils/i18n.js`. Any new user-facing string → add keys to **all three** locale files (`en.json`, `ru.json`, `es.json`).
+- **Question generation is centralized** in `src/utils/questionGenerator.js`. Add new question shapes there rather than inline in screens.
+- **Every navigable screen must be registered** in `src/navigation/AppNavigator.js`.
+- **Min touch target 44pt** (`SIZING.MIN_TOUCH_TARGET`) — respect this for kid usability.
 
-### When Adding Features
-1. **Keep it simple**: This is an educational app for kids
-2. **Maintain bare RN structure**: No Expo dependencies
-3. **Test on Android**: Primary platform
-4. **Follow existing patterns**: Functional components, hooks, StyleSheet
+## Adding a feature — typical flow
 
-### When Modifying Code
-- Preserve the color scheme defined in `colors` object
-- Keep the professor corgi background image
-- Maintain kid-friendly UI/UX (large fonts, clear feedback)
-- Test math logic edge cases (subtraction results, input validation)
+1. New screen → create under `src/screens/{learning,games}/` and register in `AppNavigator.js`.
+2. Shared component → `src/components/common/`.
+3. New strings → add to `en.json` / `ru.json` / `es.json` (keep keys in sync).
+4. New math question type → extend `questionGenerator.js`.
+5. New progress-tracked skill → extend `defaultProgress.skillsTracked` in `ProgressContext.js` and the branching in `recordAttempt`.
+6. New reward/zone → extend `RewardContext` (stages in `TREE_STAGES`).
 
-### When Debugging
-- Check Metro bundler is running (`npm start`)
-- Verify device connection (`adb devices`)
-- Clear caches if needed (`npm start -- --reset-cache`)
-- Clean Android build (`cd android && ./gradlew clean`)
+## Build & run
 
-## Build System
+Prereqs: Node 16+, JDK 17+, Android SDK 34, an emulator or device with USB debugging.
 
-### Android Configuration
-- **Package**: `com.kidslearnmath`
-- **Min SDK**: 23 (Android 6.0)
-- **Target SDK**: 34 (Android 14)
-- **Build Tools**: 34.0.0
+```bash
+npm install
+npm start             # Metro bundler (terminal 1)
+npm run android       # build + install on Android (terminal 2)
+```
 
-### Scripts
-- `npm start` - Start Metro bundler
-- `npm run android` - Build and run on Android
-- `npm test` - Placeholder (no tests currently)
+Troubleshooting is in `README.md` and `QUICK_START.md`.
 
-## Technical Constraints
+## What to avoid
 
-### What to Avoid
-- Do not add Expo dependencies
-- Do not use experimental React Native features (New Architecture is disabled)
-- Do not add heavy libraries without discussion (keep bundle size reasonable)
-- Do not modify native Android code without testing thoroughly
+- **Do not add Expo.** This is bare RN on purpose.
+- **Do not hardcode user-facing strings.** Everything renders through `t()`.
+- **Do not bypass the context providers** for settings/progress/rewards — persistence and derived state live there.
+- **Do not enable the RN New Architecture** without explicit coordination — not wired up, known to need Gradle changes.
+- **Do not add heavy libraries** for features that can be written in a few lines (the app targets low-end Android devices).
+- **Do not add leaderboards, scoreboards, or timers.** The product deliberately avoids competitive/stress mechanics (see `requirements/prd.md` §6).
 
-### What to Consider
-- This is a learning project - prioritize clarity over complexity
-- Performance matters (kids expect instant feedback)
-- Accessibility is important but not yet implemented
-- No backend/API - fully client-side app
+## Testing
 
-## Future Enhancement Ideas
-- Score tracking and persistence
-- Difficulty levels (larger numbers, multiplication/division)
-- Timer/speed challenges
-- Multiple mascots or themes
-- Sound effects and animations
-- iOS support
-- Accessibility features (VoiceOver, TalkBack)
-- Unit tests and E2E tests
+There are no automated tests yet. `npm test` is a stub. When adding tests, use Jest + React Native Testing Library; focus on `questionGenerator.js` (pure, high-value) and context reducers first.
 
-## Common Tasks
+## Where to learn the product intent
 
-### Adding a New Feature
-1. Modify `App.js` (or create new component)
-2. Update state management if needed
-3. Add styling to StyleSheet
-4. Test on Android device/emulator
-5. Update README if user-facing
+- `requirements/prd.md` — full product requirements (in Russian)
+- `requirements/1. MVP.md` — MVP user stories & acceptance criteria (in Russian)
+- `README.md` — user-facing overview + phase checklist
+- `ASSET_SPECIFICATIONS.md` — spec for the custom art/audio not yet created
+- `QUICK_START.md` — manual test script for the current build
 
-### Updating Dependencies
-1. Update `package.json`
-2. Run `npm install`
-3. Test build: `npm run android`
-4. Clear caches if issues arise
-
-### Troubleshooting Build Issues
-1. Stop Metro: `lsof -ti:8081 | xargs kill -9`
-2. Clean Android: `cd android && ./gradlew clean && cd ..`
-3. Clear Metro cache: `npm start -- --reset-cache`
-4. Reinstall dependencies: `rm -rf node_modules && npm install`
-5. Check Android SDK path in `android/local.properties`
-
-## Code Quality Standards
-
-- Use meaningful variable names
-- Keep functions small and focused
-- Comment complex logic (especially math calculations)
-- Follow React best practices (hooks rules, component structure)
-- Maintain consistent code formatting
-- Handle edge cases (empty input, NaN, etc.)
-
-## Testing Approach
-
-Currently no automated tests. When adding tests:
-- Use Jest for unit tests
-- Use React Native Testing Library for component tests
-- Consider Detox for E2E tests
-- Focus on math logic and user interactions
-
----
-
-**Remember**: This app is designed for children. Keep interactions simple, feedback immediate, and the experience delightful!
+When product intent and code disagree, `requirements/` wins.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+See [AGENTS.md](./AGENTS.md) for the full agent guide to this repo.
+
+Product spec (source of truth): [requirements/prd.md](./requirements/prd.md) and [requirements/1. MVP.md](./requirements/1.%20MVP.md).

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -224,8 +224,8 @@ ls -lh /tmp/bundle.js
 ## Support
 
 - **Documentation**: See README.md for full details
-- **Issues**: Check IMPLEMENTATION_SUMMARY.md for known limitations
-- **Architecture**: See AGENTS.md for code structure
+- **Architecture**: See AGENTS.md (or CLAUDE.md) for code structure
+- **Product spec**: See requirements/prd.md and requirements/1. MVP.md
 - **Assets**: See ASSET_SPECIFICATIONS.md for design guidelines
 
 ## Success Criteria

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ cd ..
 - [ ] Performance optimization
 - [ ] iOS support
 
-See `/mvp-development-plan.plan.md` for complete roadmap.
+See `requirements/1. MVP.md` and `requirements/prd.md` for the full product spec and roadmap.
 
 ## Asset Development
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -82,7 +82,13 @@
     "understanding_addition": "Understanding Addition",
     "understanding_subtraction": "Understanding Subtraction",
     "pattern_recognition": "Pattern Recognition",
-    "logical_thinking": "Logical Thinking"
+    "logical_thinking": "Logical Thinking",
+    "until_next": "{{count}} more leaves until {{stage}}",
+    "tree_stage": {
+      "sapling": "Sapling",
+      "young_tree": "Young Tree",
+      "flowering": "Flowering Tree"
+    }
   },
   "achievements": {
     "title": "Achievements",
@@ -148,7 +154,12 @@
     "play_again": "Play Again",
     "main_menu": "Main Menu",
     "pause": "Pause",
-    "resume": "Resume"
+    "resume": "Resume",
+    "pairs": "Pairs",
+    "moves": "Moves",
+    "round": "Round",
+    "choose_missing_number": "Choose the missing number:",
+    "open_door": "Choose the correct answer to open the door!"
   }
 }
 

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -82,7 +82,13 @@
     "understanding_addition": "Comprensión de la Suma",
     "understanding_subtraction": "Comprensión de la Resta",
     "pattern_recognition": "Reconocimiento de Patrones",
-    "logical_thinking": "Pensamiento Lógico"
+    "logical_thinking": "Pensamiento Lógico",
+    "until_next": "{{count}} hojas más para {{stage}}",
+    "tree_stage": {
+      "sapling": "Retoño",
+      "young_tree": "Árbol Joven",
+      "flowering": "Árbol en Flor"
+    }
   },
   "achievements": {
     "title": "Logros",
@@ -148,7 +154,12 @@
     "play_again": "Jugar de Nuevo",
     "main_menu": "Menú Principal",
     "pause": "Pausa",
-    "resume": "Reanudar"
+    "resume": "Reanudar",
+    "pairs": "Pares",
+    "moves": "Movimientos",
+    "round": "Ronda",
+    "choose_missing_number": "Elige el número que falta:",
+    "open_door": "¡Elige la respuesta correcta para abrir la puerta!"
   }
 }
 

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -82,7 +82,13 @@
     "understanding_addition": "Понимание сложения",
     "understanding_subtraction": "Понимание вычитания",
     "pattern_recognition": "Распознавание закономерностей",
-    "logical_thinking": "Логическое мышление"
+    "logical_thinking": "Логическое мышление",
+    "until_next": "Ещё {{count}} листочков до стадии «{{stage}}»",
+    "tree_stage": {
+      "sapling": "Росток",
+      "young_tree": "Молодое дерево",
+      "flowering": "Цветущее дерево"
+    }
   },
   "achievements": {
     "title": "Достижения",
@@ -148,7 +154,12 @@
     "play_again": "Играть ещё",
     "main_menu": "Главное меню",
     "pause": "Пауза",
-    "resume": "Продолжить"
+    "resume": "Продолжить",
+    "pairs": "Пары",
+    "moves": "Ходы",
+    "round": "Раунд",
+    "choose_missing_number": "Выбери пропущенное число:",
+    "open_door": "Выбери правильный ответ, чтобы открыть дверь!"
   }
 }
 

--- a/src/screens/ProgressScreen.js
+++ b/src/screens/ProgressScreen.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet, ScrollView, ImageBackground, StatusBar, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, ImageBackground, StatusBar } from 'react-native';
 import { t } from '../utils/i18n';
 import { useProgress } from '../contexts/ProgressContext';
 import { useReward } from '../contexts/RewardContext';
@@ -7,11 +7,18 @@ import Card from '../components/common/Card';
 import Button from '../components/common/Button';
 import { COLORS, SIZING, TYPOGRAPHY } from '../utils/constants';
 
+// Number of correct answers a skill needs to fill its bar.
+const SKILL_MASTERY_TARGET = 20;
+
+const skillPercent = (count) =>
+  Math.min(100, Math.round(((count || 0) / SKILL_MASTERY_TARGET) * 100));
+
 const ProgressScreen = ({ navigation }) => {
-  const { getStats } = useProgress();
+  const { progress, getStats } = useProgress();
   const { treeState, getGrowthProgress } = useReward();
   const stats = getStats();
   const growth = getGrowthProgress();
+  const skills = progress.skillsTracked;
 
   return (
     <ImageBackground
@@ -28,16 +35,19 @@ const ProgressScreen = ({ navigation }) => {
         <Card style={styles.treeCard}>
           <Text style={styles.treeEmoji}>🌳</Text>
           <Text style={styles.treeStage}>
-            {treeState.stage.charAt(0).toUpperCase() + treeState.stage.slice(1).replace('_', ' ')}
+            {t(`progress.tree_stage.${treeState.stage}`)}
           </Text>
-          
+
           <View style={styles.progressBar}>
             <View style={[styles.progressFill, { width: `${growth.progress}%` }]} />
           </View>
-          
+
           {growth.next && (
             <Text style={styles.progressText}>
-              {growth.leavesUntilNext} {t('progress.leaves_earned').toLowerCase()} until {growth.next.name.replace('_', ' ')}
+              {t('progress.until_next', {
+                count: growth.leavesUntilNext,
+                stage: t(`progress.tree_stage.${growth.next.name}`),
+              })}
             </Text>
           )}
         </Card>
@@ -78,7 +88,7 @@ const ProgressScreen = ({ navigation }) => {
             <View style={styles.skillInfo}>
               <Text style={styles.skillName}>{t('progress.understanding_addition')}</Text>
               <View style={styles.skillBar}>
-                <View style={[styles.skillFill, { width: '70%', backgroundColor: COLORS.success }]} />
+                <View style={[styles.skillFill, { width: `${skillPercent(skills.addition)}%`, backgroundColor: COLORS.success }]} />
               </View>
             </View>
           </View>
@@ -88,7 +98,7 @@ const ProgressScreen = ({ navigation }) => {
             <View style={styles.skillInfo}>
               <Text style={styles.skillName}>{t('progress.understanding_subtraction')}</Text>
               <View style={styles.skillBar}>
-                <View style={[styles.skillFill, { width: '60%', backgroundColor: COLORS.path }]} />
+                <View style={[styles.skillFill, { width: `${skillPercent(skills.subtraction)}%`, backgroundColor: COLORS.path }]} />
               </View>
             </View>
           </View>
@@ -98,7 +108,7 @@ const ProgressScreen = ({ navigation }) => {
             <View style={styles.skillInfo}>
               <Text style={styles.skillName}>{t('progress.pattern_recognition')}</Text>
               <View style={styles.skillBar}>
-                <View style={[styles.skillFill, { width: '50%', backgroundColor: COLORS.softPurple }]} />
+                <View style={[styles.skillFill, { width: `${skillPercent(skills.patternRecognition)}%`, backgroundColor: COLORS.softPurple }]} />
               </View>
             </View>
           </View>
@@ -108,7 +118,7 @@ const ProgressScreen = ({ navigation }) => {
             <View style={styles.skillInfo}>
               <Text style={styles.skillName}>{t('progress.logical_thinking')}</Text>
               <View style={styles.skillBar}>
-                <View style={[styles.skillFill, { width: '55%', backgroundColor: COLORS.mint }]} />
+                <View style={[styles.skillFill, { width: `${skillPercent(skills.logicalThinking)}%`, backgroundColor: COLORS.mint }]} />
               </View>
             </View>
           </View>

--- a/src/screens/games/FindPairScreen.js
+++ b/src/screens/games/FindPairScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { View, Text, StyleSheet, ImageBackground, StatusBar, TouchableOpacity } from 'react-native';
 import { t } from '../../utils/i18n';
 import { generatePairs } from '../../utils/questionGenerator';
@@ -132,7 +132,7 @@ const FindPairScreen = ({ navigation }) => {
             <Text style={styles.subtitle}>{t('games.match_cards')}</Text>
             <Text style={styles.instruction}>{t('difficulty.choose_level')}</Text>
             
-            {Object.entries(DIFFICULTY_LEVELS).map(([key, level]) => (
+            {Object.keys(DIFFICULTY_LEVELS).map((key) => (
               <Button
                 key={key}
                 title={t(`difficulty.${key}`)}
@@ -164,8 +164,12 @@ const FindPairScreen = ({ navigation }) => {
       <View style={styles.gameContainer}>
         <Card style={styles.headerCard}>
           <View style={styles.header}>
-            <Text style={styles.scoreText}>Pairs: {matchedPairs.length} / {pairs.length}</Text>
-            <Text style={styles.movesText}>Moves: {moves}</Text>
+            <Text style={styles.scoreText}>
+              {t('game_ui.pairs')}: {matchedPairs.length} / {pairs.length}
+            </Text>
+            <Text style={styles.movesText}>
+              {t('game_ui.moves')}: {moves}
+            </Text>
           </View>
         </Card>
 

--- a/src/screens/games/LostNumbersScreen.js
+++ b/src/screens/games/LostNumbersScreen.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, ImageBackground, StatusBar, TouchableOpacity } from 'react-native';
 import { t } from '../../utils/i18n';
-import { generateSequence } from '../../utils/questionGenerator';
+import { generateSequence, generateOptions } from '../../utils/questionGenerator';
 import { useProgress } from '../../contexts/ProgressContext';
 import { useReward } from '../../contexts/RewardContext';
 import Button from '../../components/common/Button';
@@ -35,7 +35,6 @@ const LostNumbersScreen = ({ navigation }) => {
   };
 
   const handleNumberSelect = async (number) => {
-    const currentMissingPos = sequence.missingIndices[currentMissingIndex];
     const correctAnswer = sequence.answers[currentMissingIndex];
     const isCorrect = number === correctAnswer;
     
@@ -80,21 +79,9 @@ const LostNumbersScreen = ({ navigation }) => {
 
   const getNumberOptions = () => {
     if (!sequence) return [];
-    
-    const currentAnswer = sequence.answers[currentMissingIndex];
-    const options = [currentAnswer];
-    const used = new Set([currentAnswer]);
-    
-    while (options.length < 6) {
-      const offset = Math.floor(Math.random() * 10) - 5;
-      const option = currentAnswer + offset;
-      if (option >= 0 && !used.has(option)) {
-        options.push(option);
-        used.add(option);
-      }
-    }
-    
-    return options.sort((a, b) => a - b);
+    const correct = sequence.answers[currentMissingIndex];
+    // 1 correct + 5 distractors, sorted ascending for a stable layout
+    return generateOptions(correct, 5).sort((a, b) => a - b);
   };
 
   if (!difficulty) {
@@ -111,7 +98,7 @@ const LostNumbersScreen = ({ navigation }) => {
             <Text style={styles.subtitle}>{t('games.complete_sequence')}</Text>
             <Text style={styles.instruction}>{t('difficulty.choose_level')}</Text>
             
-            {Object.entries(DIFFICULTY_LEVELS).map(([key, level]) => (
+            {Object.keys(DIFFICULTY_LEVELS).map((key) => (
               <Button
                 key={key}
                 title={t(`difficulty.${key}`)}
@@ -153,8 +140,12 @@ const LostNumbersScreen = ({ navigation }) => {
       <View style={styles.container}>
         <Card style={styles.card}>
           <View style={styles.header}>
-            <Text style={styles.scoreText}>Round: {roundCount + 1} / 5</Text>
-            <Text style={styles.scoreText}>{t('game_ui.score')}: {score}</Text>
+            <Text style={styles.scoreText}>
+              {t('game_ui.round')}: {roundCount + 1} / 5
+            </Text>
+            <Text style={styles.scoreText}>
+              {t('game_ui.score')}: {score}
+            </Text>
           </View>
 
           <Text style={styles.instruction}>{t('games.complete_sequence')}</Text>
@@ -187,7 +178,7 @@ const LostNumbersScreen = ({ navigation }) => {
             })}
           </View>
 
-          <Text style={styles.optionsLabel}>Choose the missing number:</Text>
+          <Text style={styles.optionsLabel}>{t('game_ui.choose_missing_number')}</Text>
 
           <View style={styles.optionsGrid}>
             {options.map((option, index) => (

--- a/src/screens/games/NumberLabyrinthScreen.js
+++ b/src/screens/games/NumberLabyrinthScreen.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, ImageBackground, StatusBar } from 'react-native';
 import { t } from '../../utils/i18n';
-import { generateQuestion } from '../../utils/questionGenerator';
+import { generateQuestion, generateOptions } from '../../utils/questionGenerator';
 import { useProgress } from '../../contexts/ProgressContext';
 import { useReward } from '../../contexts/RewardContext';
 import Button from '../../components/common/Button';
@@ -53,24 +53,8 @@ const NumberLabyrinthScreen = ({ navigation }) => {
     navigation.goBack();
   };
 
-  // Generate multiple choice options
-  const getOptions = () => {
-    if (!question) return [];
-    
-    const options = [question.answer];
-    const used = new Set([question.answer]);
-    
-    while (options.length < 4) {
-      const offset = Math.floor(Math.random() * 10) - 5;
-      const option = question.answer + offset;
-      if (option >= 0 && !used.has(option)) {
-        options.push(option);
-        used.add(option);
-      }
-    }
-    
-    return options.sort(() => Math.random() - 0.5);
-  };
+  // 1 correct + 3 distractors, shuffled
+  const getOptions = () => (question ? generateOptions(question.answer, 3) : []);
 
   if (!difficulty) {
     return (
@@ -86,7 +70,7 @@ const NumberLabyrinthScreen = ({ navigation }) => {
             <Text style={styles.subtitle}>{t('games.help_robot')}</Text>
             <Text style={styles.instruction}>{t('difficulty.choose_level')}</Text>
             
-            {Object.entries(DIFFICULTY_LEVELS).map(([key, level]) => (
+            {Object.keys(DIFFICULTY_LEVELS).map((key) => (
               <Button
                 key={key}
                 title={t(`difficulty.${key}`)}
@@ -128,8 +112,12 @@ const NumberLabyrinthScreen = ({ navigation }) => {
       <View style={styles.container}>
         <Card style={styles.card}>
           <View style={styles.header}>
-            <Text style={styles.scoreText}>{t('game_ui.score')}: {score} / 10</Text>
-            <Text style={styles.movesText}>Moves: {moves}</Text>
+            <Text style={styles.scoreText}>
+              {t('game_ui.score')}: {score} / 10
+            </Text>
+            <Text style={styles.movesText}>
+              {t('game_ui.moves')}: {moves}
+            </Text>
           </View>
 
           <Text style={styles.robotEmoji}>🤖</Text>
@@ -138,7 +126,7 @@ const NumberLabyrinthScreen = ({ navigation }) => {
             <Text style={styles.questionText}>{question.text} = ?</Text>
           </View>
 
-          <Text style={styles.instruction}>Choose the correct answer to open the door!</Text>
+          <Text style={styles.instruction}>{t('game_ui.open_door')}</Text>
 
           <View style={styles.optionsGrid}>
             {options.map((option, index) => (

--- a/src/screens/learning/AdditionVisualScreen.js
+++ b/src/screens/learning/AdditionVisualScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { View, Text, StyleSheet, ImageBackground, StatusBar, TouchableOpacity, TextInput } from 'react-native';
 import { t } from '../../utils/i18n';
 import { generateVisualQuestion } from '../../utils/questionGenerator';
@@ -34,7 +34,7 @@ const AdditionVisualScreen = ({ navigation }) => {
 
   const checkAnswer = async () => {
     const answer = parseInt(userAnswer, 10);
-    
+
     if (isNaN(answer)) {
       setFeedback(t('common.incorrect'));
       return;
@@ -46,29 +46,19 @@ const AdditionVisualScreen = ({ navigation }) => {
     if (isCorrect) {
       setFeedback(t('common.correct'));
       setScore(score + 1);
-      
-      setTimeout(() => {
-        const nextCount = questionCount + 1;
-        if (nextCount >= GAME_CONFIG.TOTAL_QUESTIONS) {
-          finishLesson();
-        } else {
-          setQuestionCount(nextCount);
-          generateNewQuestion(difficulty);
-        }
-      }, GAME_CONFIG.FEEDBACK_DELAY);
     } else {
       setFeedback(t('common.incorrect'));
-      
-      setTimeout(() => {
-        const nextCount = questionCount + 1;
-        if (nextCount >= GAME_CONFIG.TOTAL_QUESTIONS) {
-          finishLesson();
-        } else {
-          setQuestionCount(nextCount);
-          generateNewQuestion(difficulty);
-        }
-      }, GAME_CONFIG.FEEDBACK_DELAY);
     }
+
+    setTimeout(() => {
+      const nextCount = questionCount + 1;
+      if (nextCount >= GAME_CONFIG.TOTAL_QUESTIONS) {
+        finishLesson();
+      } else {
+        setQuestionCount(nextCount);
+        generateNewQuestion(difficulty);
+      }
+    }, GAME_CONFIG.FEEDBACK_DELAY);
   };
 
   const finishLesson = async () => {
@@ -106,7 +96,7 @@ const AdditionVisualScreen = ({ navigation }) => {
             <Text style={styles.title}>{t('learning.addition')}</Text>
             <Text style={styles.subtitle}>{t('difficulty.choose_level')}</Text>
             
-            {Object.entries(DIFFICULTY_LEVELS).map(([key, level]) => (
+            {Object.keys(DIFFICULTY_LEVELS).map((key) => (
               <Button
                 key={key}
                 title={t(`difficulty.${key}`)}

--- a/src/screens/learning/StoryProblemsScreen.js
+++ b/src/screens/learning/StoryProblemsScreen.js
@@ -103,7 +103,7 @@ const StoryProblemsScreen = ({ navigation }) => {
             <Text style={styles.title}>{t('learning.story_problems')}</Text>
             <Text style={styles.subtitle}>{t('difficulty.choose_level')}</Text>
             
-            {Object.entries(DIFFICULTY_LEVELS).map(([key, level]) => (
+            {Object.keys(DIFFICULTY_LEVELS).map((key) => (
               <Button
                 key={key}
                 title={t(`difficulty.${key}`)}

--- a/src/screens/learning/SubtractionVisualScreen.js
+++ b/src/screens/learning/SubtractionVisualScreen.js
@@ -16,8 +16,7 @@ const SubtractionVisualScreen = ({ navigation }) => {
   const [questionCount, setQuestionCount] = useState(0);
   const [score, setScore] = useState(0);
   const [sessionStart] = useState(Date.now());
-  const [removedCount, setRemovedCount] = useState(0);
-  
+
   const { recordAttempt, completeLesson } = useProgress();
   const { addLeaves } = useReward();
 
@@ -31,12 +30,11 @@ const SubtractionVisualScreen = ({ navigation }) => {
     setQuestion(newQuestion);
     setUserAnswer('');
     setFeedback('');
-    setRemovedCount(0);
   };
 
   const checkAnswer = async () => {
     const answer = parseInt(userAnswer, 10);
-    
+
     if (isNaN(answer)) {
       setFeedback(t('common.incorrect'));
       return;
@@ -48,29 +46,19 @@ const SubtractionVisualScreen = ({ navigation }) => {
     if (isCorrect) {
       setFeedback(t('common.correct'));
       setScore(score + 1);
-      
-      setTimeout(() => {
-        const nextCount = questionCount + 1;
-        if (nextCount >= GAME_CONFIG.TOTAL_QUESTIONS) {
-          finishLesson();
-        } else {
-          setQuestionCount(nextCount);
-          generateNewQuestion(difficulty);
-        }
-      }, GAME_CONFIG.FEEDBACK_DELAY);
     } else {
       setFeedback(t('common.incorrect'));
-      
-      setTimeout(() => {
-        const nextCount = questionCount + 1;
-        if (nextCount >= GAME_CONFIG.TOTAL_QUESTIONS) {
-          finishLesson();
-        } else {
-          setQuestionCount(nextCount);
-          generateNewQuestion(difficulty);
-        }
-      }, GAME_CONFIG.FEEDBACK_DELAY);
     }
+
+    setTimeout(() => {
+      const nextCount = questionCount + 1;
+      if (nextCount >= GAME_CONFIG.TOTAL_QUESTIONS) {
+        finishLesson();
+      } else {
+        setQuestionCount(nextCount);
+        generateNewQuestion(difficulty);
+      }
+    }, GAME_CONFIG.FEEDBACK_DELAY);
   };
 
   const finishLesson = async () => {
@@ -117,7 +105,7 @@ const SubtractionVisualScreen = ({ navigation }) => {
             <Text style={styles.title}>{t('learning.subtraction')}</Text>
             <Text style={styles.subtitle}>{t('difficulty.choose_level')}</Text>
             
-            {Object.entries(DIFFICULTY_LEVELS).map(([key, level]) => (
+            {Object.keys(DIFFICULTY_LEVELS).map((key) => (
               <Button
                 key={key}
                 title={t(`difficulty.${key}`)}

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -19,21 +19,9 @@ export const COLORS = {
 
 // Difficulty levels configuration
 export const DIFFICULTY_LEVELS = {
-  easy: {
-    name: 'easy',
-    maxNumber: 10,
-    minigameLevels: 3,
-  },
-  medium: {
-    name: 'medium',
-    maxNumber: 20,
-    minigameLevels: 5,
-  },
-  hard: {
-    name: 'hard',
-    maxNumber: 50,
-    minigameLevels: 8,
-  },
+  easy: { maxNumber: 10 },
+  medium: { maxNumber: 20 },
+  hard: { maxNumber: 50 },
 };
 
 // Game configuration
@@ -41,8 +29,6 @@ export const GAME_CONFIG = {
   TOTAL_QUESTIONS: 10,
   HINT_AFTER_ATTEMPTS: 2,
   FEEDBACK_DELAY: 800,
-  SESSION_MIN_DURATION: 5, // minutes
-  SESSION_MAX_DURATION: 12, // minutes
 };
 
 // Tree of Reason growth stages

--- a/src/utils/questionGenerator.js
+++ b/src/utils/questionGenerator.js
@@ -171,81 +171,22 @@ export const generatePairs = (difficulty, count = 6) => {
 };
 
 /**
- * Generate labyrinth puzzle
- * Returns a grid with positions and questions
+ * Generate `count` plausible-but-wrong distractors plus the correct answer,
+ * shuffled. Distractors are chosen near the correct answer (±5) and are
+ * unique and non-negative.
  */
-export const generateLabyrinthLevel = (difficulty, size = 4) => {
-  const grid = [];
-  const path = []; // Correct path through the maze
-  
-  // Generate simple path (for MVP: straight or simple turns)
-  let currentPos = { x: 0, y: 0 };
-  path.push({ ...currentPos });
-  
-  // Create path to end (simplified for MVP)
-  while (currentPos.x < size - 1 || currentPos.y < size - 1) {
-    const canGoRight = currentPos.x < size - 1;
-    const canGoDown = currentPos.y < size - 1;
-    
-    if (canGoRight && canGoDown) {
-      // Randomly choose
-      if (Math.random() < 0.5) {
-        currentPos.x++;
-      } else {
-        currentPos.y++;
-      }
-    } else if (canGoRight) {
-      currentPos.x++;
-    } else {
-      currentPos.y++;
-    }
-    
-    path.push({ ...currentPos });
-  }
-  
-  // Generate questions for each position
-  for (let y = 0; y < size; y++) {
-    for (let x = 0; x < size; x++) {
-      const isOnPath = path.some(p => p.x === x && p.y === y);
-      const question = generateQuestion(difficulty);
-      
-      grid.push({
-        x,
-        y,
-        isOnPath,
-        question: question.text,
-        answer: question.answer,
-        options: generateOptions(question.answer, 3),
-      });
-    }
-  }
-  
-  return {
-    grid,
-    path,
-    size,
-    start: { x: 0, y: 0 },
-    end: { x: size - 1, y: size - 1 },
-  };
-};
-
-/**
- * Generate multiple choice options including the correct answer
- */
-const generateOptions = (correctAnswer, count = 3) => {
+export const generateOptions = (correctAnswer, count = 3) => {
   const options = [correctAnswer];
-  
+
   while (options.length < count + 1) {
-    // Generate similar numbers (±1 to ±5)
     const offset = Math.floor(Math.random() * 10) - 5;
     const option = correctAnswer + offset;
-    
+
     if (option >= 0 && !options.includes(option)) {
       options.push(option);
     }
   }
-  
-  // Shuffle options
+
   return options.sort(() => Math.random() - 0.5);
 };
 


### PR DESCRIPTION
## Summary

Audits the repo against its plans (`requirements/prd.md`, `requirements/1. MVP.md`), updates agent-facing docs so they match the current code, and strips dead/duplicate code without changing gameplay.

## AI-readiness

- **`AGENTS.md` rewritten.** The old version described a single-file `App.js`; reality is a modular RN app with context providers, navigation, i18n, and split learning/game screens. New version covers stack, layout, state, conventions, "add a feature" flow, and product guardrails (no Expo, no leaderboards/timers, every string through `t()`).
- **`CLAUDE.md` added** as a thin pointer to `AGENTS.md` and the requirements docs.
- **Fixed dangling doc links**: `README.md` referenced a nonexistent `mvp-development-plan.plan.md`; `QUICK_START.md` referenced a nonexistent `IMPLEMENTATION_SUMMARY.md`.

## Code cleanup (no behavior change)

- Removed dead code: `generateLabyrinthLevel` (never called), `removedCount` state in `SubtractionVisualScreen`, `minigameLevels` / `SESSION_MIN_DURATION` / `SESSION_MAX_DURATION` constants, unused `useEffect` / `TouchableOpacity` imports, unused `level` var in every `Object.entries(DIFFICULTY_LEVELS)` call.
- Exported `generateOptions` from `questionGenerator.js`; `LostNumbersScreen` and `NumberLabyrinthScreen` now share it instead of each inlining its own distractor loop.
- Deduped the identical correct/incorrect `setTimeout` branches in `AdditionVisualScreen` and `SubtractionVisualScreen`.
- Replaced hardcoded English strings ("Pairs:", "Moves:", "Round:", "Choose the missing number:", "Choose the correct answer…", tree stage names) with `t()` lookups; added the new keys to `en.json` / `ru.json` / `es.json`.

## Bug fix

- `ProgressScreen` skill bars were hardcoded at 70/60/50/55% placeholders. They now compute from `progress.skillsTracked` against a `SKILL_MASTERY_TARGET` of 20 correct answers per skill.

## Reviewer notes

- `ACHIEVEMENTS` constant and `ProgressContext.unlockAchievement` are kept even though nothing calls them yet — they're API surface for achievements work planned in Phase 2. Flag if you'd rather see them removed.
- No tests exist in the repo (`npm test` is a stub), so verification is by code review + Metro build. Touched files pass `node --check` where applicable and all three locale JSONs parse.

## Test plan

- [ ] `npm install && npm start` — Metro bundles without errors
- [ ] `npm run android` — app launches
- [ ] Walk Welcome → Main Menu → each learning module → each game → Progress → Settings
- [ ] Switch language EN ↔ RU ↔ ES and confirm the new strings (Pairs, Moves, Round, tree stages, "until next") render in each
- [ ] Complete a lesson and confirm the matching skill bar in Progress grows (was previously frozen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)