### PR TITLE
chore: pin JDK 17 for Android builds via .sdkmanrc

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Install the required JDK via: sdk env install
+java=17.0.18-tem


### PR DESCRIPTION
## Summary
- Add `.sdkmanrc` pinning `java=17.0.18-tem` so SDKMAN auto-switches to JDK 17 when entering the repo.

## Why
React Native 0.74 ships with Android Gradle Plugin 8.1, which officially supports JDK 17. Newer JDKs (21/25) tend to trip Gradle/Kotlin compatibility warnings or outright failures. Pinning via `.sdkmanrc` keeps the project build deterministic regardless of the developer's global `sdk default java`.

## Reviewer notes
- Requires `sdkman_auto_env=true` in `~/.sdkman/etc/config` for the automatic switch; otherwise run `sdk env` manually.
- Verified end-to-end: `npm run android` built and installed the app on a fresh `Pixel_6_API_34` AVD (Android 14, `google_apis/arm64-v8a`), build took ~4m, app launched successfully.

## Test plan
- [ ] `cd` into the repo in a fresh shell and confirm `java --version` reports 17.0.18
- [ ] `npm run android` completes `BUILD SUCCESSFUL` on an Android 34 emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)