### PR TITLE
Onboarding + cross-screen UX polish

### DIFF
--- a/src/components/common/BackButton.js
+++ b/src/components/common/BackButton.js
@@ -77,7 +77,7 @@ const styles = StyleSheet.create({
     minHeight: SIZING.SECONDARY_TARGET,
     minWidth: SIZING.SECONDARY_TARGET,
     paddingHorizontal: SIZING.PADDING.medium,
-    borderBottomColor: COLORS.skyDeep,
+    borderBottomColor: COLORS.pressShadow,
     borderBottomWidth: 3,
   },
   arrow: {

--- a/src/components/common/Button.js
+++ b/src/components/common/Button.js
@@ -3,13 +3,13 @@ import { Pressable, Text, StyleSheet, ActivityIndicator, View } from 'react-nati
 import { COLORS, SIZING, TYPOGRAPHY, SHADOWS } from '../../utils/constants';
 
 const VARIANT_COLORS = {
-  primary:   { face: COLORS.path,           lip: COLORS.pathDeep,        text: COLORS.white },
-  secondary: { face: COLORS.grass,          lip: COLORS.grassDeep,       text: COLORS.white },
-  success:   { face: COLORS.success,        lip: COLORS.successDeep,     text: COLORS.white },
-  error:     { face: COLORS.error,          lip: COLORS.errorDeep,       text: COLORS.white },
-  purple:    { face: COLORS.softPurpleDeep, lip: '#8A5FB8',              text: COLORS.white },
-  sky:       { face: COLORS.skyDeep,        lip: '#4FA6CE',              text: COLORS.white },
-  outline:   { face: COLORS.white,          lip: COLORS.path,            text: COLORS.path, outline: true },
+  primary:   { face: COLORS.path,           lip: COLORS.pathDeep,       text: COLORS.white },
+  secondary: { face: COLORS.grass,          lip: COLORS.grassDeep,      text: COLORS.white },
+  success:   { face: COLORS.success,        lip: COLORS.successDeep,    text: COLORS.white },
+  error:     { face: COLORS.error,          lip: COLORS.errorDeep,      text: COLORS.white },
+  purple:    { face: COLORS.softPurpleDeep, lip: COLORS.softPurpleLip,  text: COLORS.white },
+  sky:       { face: COLORS.skyDeep,        lip: COLORS.skyLip,         text: COLORS.white },
+  outline:   { face: COLORS.white,          lip: COLORS.path,           text: COLORS.path, outline: true },
 };
 
 const Button = ({

--- a/src/components/common/ScreenBackground.js
+++ b/src/components/common/ScreenBackground.js
@@ -19,6 +19,18 @@ const TINTS = {
     bg: COLORS.bgLavender,
     bubbles: ['#FFFFFF', COLORS.softPurple, COLORS.warmYellow, COLORS.mint],
   },
+  teal: {
+    bg: COLORS.bgTeal,
+    bubbles: ['#FFFFFF', COLORS.mint, COLORS.sky, COLORS.warmYellow],
+  },
+  rose: {
+    bg: COLORS.bgRose,
+    bubbles: ['#FFFFFF', COLORS.softRed, COLORS.peach, COLORS.softPurple],
+  },
+  lemon: {
+    bg: COLORS.bgLemon,
+    bubbles: ['#FFFFFF', COLORS.warmYellow, COLORS.peach, COLORS.mint],
+  },
 };
 
 const BUBBLES = [

--- a/src/components/common/TileButton.js
+++ b/src/components/common/TileButton.js
@@ -3,14 +3,14 @@ import { View, Text, Pressable, StyleSheet } from 'react-native';
 import { COLORS, SIZING, TYPOGRAPHY, SHADOWS } from '../../utils/constants';
 
 const PALETTES = {
-  sky:      { face: COLORS.skyDeep,        lip: '#4FA6CE',      text: COLORS.white },
-  grass:    { face: COLORS.grassDeep,      lip: '#3E9A40',      text: COLORS.white },
-  path:     { face: COLORS.path,           lip: COLORS.pathDeep, text: COLORS.white },
-  purple:   { face: COLORS.softPurpleDeep, lip: '#8A5FB8',      text: COLORS.white },
-  mint:     { face: COLORS.mintDeep,       lip: '#3FA07F',      text: COLORS.white },
-  yellow:   { face: COLORS.warmYellowDeep, lip: '#C99A1F',      text: COLORS.text  },
-  peach:    { face: COLORS.peachDeep,      lip: '#E08848',      text: COLORS.white },
-  red:      { face: COLORS.softRedDeep,    lip: COLORS.errorDeep, text: COLORS.white },
+  sky:      { face: COLORS.skyDeep,        lip: COLORS.skyLip,         text: COLORS.white },
+  grass:    { face: COLORS.grassDeep,      lip: COLORS.grassLip,       text: COLORS.white },
+  path:     { face: COLORS.path,           lip: COLORS.pathDeep,       text: COLORS.white },
+  purple:   { face: COLORS.softPurpleDeep, lip: COLORS.softPurpleLip,  text: COLORS.white },
+  mint:     { face: COLORS.mintDeep,       lip: COLORS.mintLip,        text: COLORS.white },
+  yellow:   { face: COLORS.warmYellowDeep, lip: COLORS.warmYellowLip,  text: COLORS.text  },
+  peach:    { face: COLORS.peachDeep,      lip: COLORS.peachLip,       text: COLORS.white },
+  red:      { face: COLORS.softRedDeep,    lip: COLORS.errorDeep,      text: COLORS.white },
 };
 
 const TileButton = ({

--- a/src/screens/MainMenuScreen.js
+++ b/src/screens/MainMenuScreen.js
@@ -1,7 +1,8 @@
-import React from 'react';
-import { View, Text, StyleSheet, ScrollView, Image, Pressable } from 'react-native';
+import React, { useEffect } from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { t } from '../utils/i18n';
+import { useProgress } from '../contexts/ProgressContext';
 import ScreenBackground from '../components/common/ScreenBackground';
 import TileButton from '../components/common/TileButton';
 import { COLORS, SIZING, TYPOGRAPHY, SHADOWS } from '../utils/constants';
@@ -19,25 +20,20 @@ const GAME_TILES = [
 ];
 
 const MainMenuScreen = ({ navigation }) => {
+  const { startSession, isLoading } = useProgress();
+
+  // Session kickoff runs here rather than WelcomeScreen so that returning
+  // kids (who skip Welcome via the first-launch flag) still get a session
+  // recorded. Fires once on first mount — stack nav keeps MainMenu mounted
+  // across lesson trips so this doesn't double-count.
+  useEffect(() => {
+    if (!isLoading) startSession();
+  }, [isLoading]);
+
   return (
     <ScreenBackground tint="sky">
-      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
-        <ScrollView
-          style={styles.scroll}
-          contentContainerStyle={styles.scrollContent}
-          showsVerticalScrollIndicator={false}
-        >
-          <View style={styles.headerRow}>
-            <Image
-              source={require('../../assets/professor-corgi.jpeg')}
-              style={styles.avatar}
-            />
-            <View style={styles.headerText}>
-              <Text style={styles.hello}>{t('menu.title')}</Text>
-              <Text style={styles.helloSub}>{t('welcome.question')}</Text>
-            </View>
-          </View>
-
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right', 'bottom']}>
+        <View style={styles.content}>
           <SectionHeader icon="📚" title={t('menu.learn_math')} />
           <View style={styles.grid}>
             {LEARN_TILES.map((item) => (
@@ -46,6 +42,7 @@ const MainMenuScreen = ({ navigation }) => {
                   title={t(item.titleKey)}
                   icon={item.icon}
                   color={item.color}
+                  size="small"
                   onPress={() => navigation.navigate(item.screen)}
                 />
               </View>
@@ -60,6 +57,7 @@ const MainMenuScreen = ({ navigation }) => {
                   title={t(item.titleKey)}
                   icon={item.icon}
                   color={item.color}
+                  size="small"
                   onPress={() => navigation.navigate(item.screen)}
                 />
               </View>
@@ -80,7 +78,7 @@ const MainMenuScreen = ({ navigation }) => {
               onPress={() => navigation.navigate('Settings')}
             />
           </View>
-        </ScrollView>
+        </View>
       </SafeAreaView>
     </ScreenBackground>
   );
@@ -115,48 +113,24 @@ const PillAction = ({ icon, label, color, onPress }) => (
 
 const styles = StyleSheet.create({
   safe: { flex: 1 },
-  scroll: { flex: 1 },
-  scrollContent: {
-    padding: SIZING.PADDING.large,
-    paddingBottom: SIZING.PADDING.xlarge,
-  },
-  headerRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: COLORS.overlay,
-    padding: SIZING.PADDING.medium,
-    borderRadius: SIZING.BORDER_RADIUS.xlarge,
-    marginBottom: SIZING.MARGIN.large,
-    ...SHADOWS.soft,
-  },
-  avatar: {
-    width: 64,
-    height: 64,
-    borderRadius: 32,
-    marginRight: SIZING.MARGIN.medium,
-  },
-  headerText: { flex: 1 },
-  hello: {
-    fontSize: TYPOGRAPHY.SIZES.title,
-    fontWeight: TYPOGRAPHY.WEIGHTS.bold,
-    color: COLORS.text,
-  },
-  helloSub: {
-    fontSize: TYPOGRAPHY.SIZES.body,
-    color: COLORS.textSoft,
+  content: {
+    flex: 1,
+    paddingHorizontal: SIZING.PADDING.large,
+    paddingTop: SIZING.PADDING.small,
+    paddingBottom: SIZING.PADDING.medium,
   },
   sectionHeader: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginTop: SIZING.MARGIN.medium,
-    marginBottom: SIZING.MARGIN.medium,
+    marginTop: SIZING.MARGIN.small,
+    marginBottom: SIZING.MARGIN.small,
   },
   sectionIcon: {
-    fontSize: 28,
+    fontSize: 24,
     marginRight: SIZING.MARGIN.small,
   },
   sectionTitle: {
-    fontSize: TYPOGRAPHY.SIZES.title,
+    fontSize: TYPOGRAPHY.SIZES.subtitle,
     fontWeight: TYPOGRAPHY.WEIGHTS.bold,
     color: COLORS.text,
   },
@@ -164,15 +138,14 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap',
     marginHorizontal: -6,
-    marginBottom: SIZING.MARGIN.medium,
   },
   gridCell: {
-    width: '50%',
+    width: '33.3333%',
     padding: SIZING.GAP / 2,
   },
   bottomRow: {
     flexDirection: 'row',
-    marginTop: SIZING.MARGIN.large,
+    marginTop: 'auto',
     gap: SIZING.MARGIN.medium,
   },
   pillWrap: {

--- a/src/screens/ProgressScreen.js
+++ b/src/screens/ProgressScreen.js
@@ -31,10 +31,6 @@ const ProgressScreen = ({ navigation }) => {
           contentContainerStyle={styles.scrollContent}
           showsVerticalScrollIndicator={false}
         >
-          <View style={styles.titlePill}>
-            <Text style={styles.title}>{t('progress.title')}</Text>
-          </View>
-
           {/* Tree Visualization */}
           <Card style={styles.treeCard} padding={false}>
             <View style={styles.treeHero}>
@@ -134,20 +130,6 @@ const styles = StyleSheet.create({
     padding: SIZING.PADDING.large,
     paddingTop: SIZING.PADDING.xlarge + SIZING.SECONDARY_TARGET,
     paddingBottom: SIZING.PADDING.xlarge,
-  },
-  titlePill: {
-    alignSelf: 'center',
-    backgroundColor: COLORS.overlay,
-    paddingHorizontal: SIZING.PADDING.large,
-    paddingVertical: SIZING.PADDING.medium,
-    borderRadius: SIZING.BORDER_RADIUS.pill,
-    marginBottom: SIZING.MARGIN.large,
-    ...SHADOWS.soft,
-  },
-  title: {
-    fontSize: TYPOGRAPHY.SIZES.title,
-    fontWeight: TYPOGRAPHY.WEIGHTS.bold,
-    color: COLORS.text,
   },
   treeCard: {
     marginBottom: SIZING.MARGIN.large,

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -6,7 +6,7 @@ import { useSettings } from '../contexts/SettingsContext';
 import Card from '../components/common/Card';
 import ScreenBackground from '../components/common/ScreenBackground';
 import BackButton from '../components/common/BackButton';
-import { COLORS, SIZING, TYPOGRAPHY, SHADOWS, LANGUAGES } from '../utils/constants';
+import { COLORS, SIZING, TYPOGRAPHY, LANGUAGES } from '../utils/constants';
 
 const LANGUAGE_OPTIONS = [
   { code: LANGUAGES.EN, name: 'English', flag: '🇬🇧' },
@@ -26,10 +26,6 @@ const SettingsScreen = ({ navigation }) => {
           contentContainerStyle={styles.scrollContent}
           showsVerticalScrollIndicator={false}
         >
-          <View style={styles.titlePill}>
-            <Text style={styles.title}>{t('settings.title')}</Text>
-          </View>
-
           <Card style={styles.card} padding={false} band="purple" bandTitle={t('settings.language')} bandIcon="🌍">
             <View style={styles.cardBody}>
               {LANGUAGE_OPTIONS.map((lang) => {
@@ -128,20 +124,6 @@ const styles = StyleSheet.create({
     padding: SIZING.PADDING.large,
     paddingTop: SIZING.PADDING.xlarge + SIZING.SECONDARY_TARGET,
     paddingBottom: SIZING.PADDING.xlarge,
-  },
-  titlePill: {
-    alignSelf: 'center',
-    backgroundColor: COLORS.overlay,
-    paddingHorizontal: SIZING.PADDING.large,
-    paddingVertical: SIZING.PADDING.medium,
-    borderRadius: SIZING.BORDER_RADIUS.pill,
-    marginBottom: SIZING.MARGIN.large,
-    ...SHADOWS.soft,
-  },
-  title: {
-    fontSize: TYPOGRAPHY.SIZES.title,
-    fontWeight: TYPOGRAPHY.WEIGHTS.bold,
-    color: COLORS.text,
   },
   card: {
     marginBottom: SIZING.MARGIN.large,

--- a/src/screens/WelcomeScreen.js
+++ b/src/screens/WelcomeScreen.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, Image } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { t } from '../utils/i18n';
@@ -6,26 +6,40 @@ import { useSettings } from '../contexts/SettingsContext';
 import { useProgress } from '../contexts/ProgressContext';
 import Button from '../components/common/Button';
 import ScreenBackground from '../components/common/ScreenBackground';
-import { COLORS, SIZING, TYPOGRAPHY, SHADOWS } from '../utils/constants';
+import { loadData, saveData } from '../utils/storage';
+import { COLORS, SIZING, TYPOGRAPHY, SHADOWS, ICON_SIZES, STORAGE_KEYS } from '../utils/constants';
 
 const WelcomeScreen = ({ navigation }) => {
   const { isLoading: settingsLoading } = useSettings();
-  const { startSession, isLoading: progressLoading } = useProgress();
+  const { isLoading: progressLoading } = useProgress();
+  // While we check AsyncStorage, render nothing so returning kids don't see
+  // the welcome flash before the auto-skip fires.
+  const [checkingFirstLaunch, setCheckingFirstLaunch] = useState(true);
 
   useEffect(() => {
-    if (!progressLoading && !settingsLoading) {
-      startSession();
-    }
+    if (progressLoading || settingsLoading) return;
+    let cancelled = false;
+    (async () => {
+      const seen = await loadData(STORAGE_KEYS.HAS_SEEN_WELCOME);
+      if (cancelled) return;
+      if (seen) {
+        navigation.replace('MainMenu');
+      } else {
+        setCheckingFirstLaunch(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, [progressLoading, settingsLoading]);
 
-  if (settingsLoading || progressLoading) {
-    return (
-      <ScreenBackground tint="sky">
-        <View style={styles.loadingContainer}>
-          <Text style={styles.loadingText}>{t('common.loading')}</Text>
-        </View>
-      </ScreenBackground>
-    );
+  const handleStart = async () => {
+    await saveData(STORAGE_KEYS.HAS_SEEN_WELCOME, true);
+    navigation.replace('MainMenu');
+  };
+
+  if (settingsLoading || progressLoading || checkingFirstLaunch) {
+    return <ScreenBackground tint="sky" />;
   }
 
   return (
@@ -48,7 +62,7 @@ const WelcomeScreen = ({ navigation }) => {
 
           <Button
             title={t('welcome.lets_start')}
-            onPress={() => navigation.navigate('MainMenu')}
+            onPress={handleStart}
             variant="primary"
             size="large"
             icon="🚀"
@@ -67,7 +81,7 @@ const WelcomeScreen = ({ navigation }) => {
   );
 };
 
-const MASCOT_SIZE = 200;
+const MASCOT_SIZE = ICON_SIZES.hero;
 
 const styles = StyleSheet.create({
   safe: { flex: 1 },
@@ -76,15 +90,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     padding: SIZING.PADDING.large,
-  },
-  loadingContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  loadingText: {
-    fontSize: TYPOGRAPHY.SIZES.title,
-    color: COLORS.text,
   },
   mascotRing: {
     width: MASCOT_SIZE + 16,

--- a/src/screens/games/FindPairScreen.js
+++ b/src/screens/games/FindPairScreen.js
@@ -117,7 +117,7 @@ const FindPairScreen = ({ navigation }) => {
   if (!difficulty) {
     return (
       <DifficultyPicker
-        tint="sunrise"
+        tint="rose"
         icon="🎴"
         title={t('games.find_pair')}
         subtitle={t('games.match_cards')}
@@ -128,7 +128,7 @@ const FindPairScreen = ({ navigation }) => {
   }
 
   return (
-    <ScreenBackground tint="sunrise">
+    <ScreenBackground tint="rose">
       <SafeAreaView style={styles.safe}>
         <BackButton confirm onPress={() => navigation.goBack()} />
         <View style={styles.container}>
@@ -217,7 +217,7 @@ const styles = StyleSheet.create({
   headerValue: {
     fontSize: TYPOGRAPHY.SIZES.title,
     fontWeight: TYPOGRAPHY.WEIGHTS.bold,
-    color: COLORS.pathDeep,
+    color: COLORS.peachDeep,
   },
   headerLabel: {
     fontSize: TYPOGRAPHY.SIZES.body,
@@ -237,17 +237,17 @@ const styles = StyleSheet.create({
   },
   cardItem: {
     flex: 1,
-    backgroundColor: COLORS.path,
+    backgroundColor: COLORS.peach,
     borderRadius: SIZING.BORDER_RADIUS.large,
     justifyContent: 'center',
     alignItems: 'center',
     borderBottomWidth: 4,
-    borderBottomColor: COLORS.pathDeep,
+    borderBottomColor: COLORS.peachDeep,
     ...SHADOWS.soft,
   },
   cardFlipped: {
     backgroundColor: COLORS.white,
-    borderBottomColor: COLORS.skyDeep,
+    borderBottomColor: COLORS.peachDeep,
   },
   cardMatched: {
     backgroundColor: COLORS.mint,

--- a/src/screens/games/LostNumbersScreen.js
+++ b/src/screens/games/LostNumbersScreen.js
@@ -15,10 +15,10 @@ import { COLORS, SIZING, TYPOGRAPHY, SHADOWS } from '../../utils/constants';
 // Four per-option color variants keep choices distinguishable without
 // relying on reading the number alone.
 const OPTION_PALETTES = [
-  { face: COLORS.skyDeep, lip: '#4FA6CE' },
-  { face: COLORS.mintDeep, lip: '#3FA07F' },
-  { face: COLORS.softPurpleDeep, lip: '#8A5FB8' },
-  { face: COLORS.peachDeep, lip: '#E08848' },
+  { face: COLORS.warmYellowDeep, lip: COLORS.warmYellowLip, text: COLORS.text },
+  { face: COLORS.mintDeep, lip: COLORS.mintLip, text: COLORS.white },
+  { face: COLORS.softPurpleDeep, lip: COLORS.softPurpleLip, text: COLORS.white },
+  { face: COLORS.peachDeep, lip: COLORS.peachLip, text: COLORS.white },
 ];
 
 const TOTAL_ROUNDS = 5;
@@ -106,7 +106,7 @@ const LostNumbersScreen = ({ navigation }) => {
   if (!difficulty) {
     return (
       <DifficultyPicker
-        tint="lavender"
+        tint="lemon"
         icon="🔢"
         title={t('games.lost_numbers')}
         subtitle={t('games.complete_sequence')}
@@ -119,7 +119,7 @@ const LostNumbersScreen = ({ navigation }) => {
   if (!sequence) return null;
 
   return (
-    <ScreenBackground tint="lavender">
+    <ScreenBackground tint="lemon">
       <SafeAreaView style={styles.safe}>
         <BackButton confirm onPress={() => navigation.goBack()} />
         <ScrollView
@@ -197,7 +197,7 @@ const LostNumbersScreen = ({ navigation }) => {
                         },
                       ]}
                     >
-                      <Text style={styles.optionText}>{option}</Text>
+                      <Text style={[styles.optionText, { color: palette.text }]}>{option}</Text>
                     </View>
                   )}
                 </Pressable>
@@ -278,7 +278,7 @@ const styles = StyleSheet.create({
   },
   sequenceBoxCurrent: {
     borderWidth: 3,
-    borderColor: COLORS.softPurpleDeep,
+    borderColor: COLORS.pathDeep,
     transform: [{ scale: 1.08 }],
   },
   sequenceBoxCorrect: {

--- a/src/screens/games/NumberLabyrinthScreen.js
+++ b/src/screens/games/NumberLabyrinthScreen.js
@@ -13,10 +13,10 @@ import useAttemptCounter from '../../hooks/useAttemptCounter';
 import { COLORS, SIZING, TYPOGRAPHY, SHADOWS } from '../../utils/constants';
 
 const OPTION_COLORS = [
-  { face: COLORS.skyDeep, lip: '#4FA6CE' },
-  { face: COLORS.softPurpleDeep, lip: '#8A5FB8' },
-  { face: COLORS.mintDeep, lip: '#3FA07F' },
-  { face: COLORS.peachDeep, lip: '#E08848' },
+  { face: COLORS.skyDeep, lip: COLORS.skyLip },
+  { face: COLORS.softPurpleDeep, lip: COLORS.softPurpleLip },
+  { face: COLORS.mintDeep, lip: COLORS.mintLip },
+  { face: COLORS.peachDeep, lip: COLORS.peachLip },
 ];
 
 const TOTAL_QUESTIONS = 10;
@@ -78,7 +78,7 @@ const NumberLabyrinthScreen = ({ navigation }) => {
   if (!difficulty) {
     return (
       <DifficultyPicker
-        tint="sky"
+        tint="teal"
         icon="🧩"
         title={t('games.number_labyrinth')}
         subtitle={t('games.help_robot')}
@@ -93,7 +93,7 @@ const NumberLabyrinthScreen = ({ navigation }) => {
   const progressPct = Math.round((score / TOTAL_QUESTIONS) * 100);
 
   return (
-    <ScreenBackground tint="sky">
+    <ScreenBackground tint="teal">
       <SafeAreaView style={styles.safe}>
         <BackButton confirm onPress={() => navigation.goBack()} />
         <View style={styles.container}>

--- a/src/screens/learning/AdditionVisualScreen.js
+++ b/src/screens/learning/AdditionVisualScreen.js
@@ -113,7 +113,7 @@ const AdditionVisualScreen = ({ navigation }) => {
 
   return (
     <ScreenBackground tint="mint">
-      <SafeAreaView style={styles.safe}>
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right', 'bottom']}>
         <BackButton confirm onPress={() => navigation.goBack()} />
         <ScrollView
           style={styles.scroll}
@@ -168,16 +168,16 @@ const AdditionVisualScreen = ({ navigation }) => {
           </Card>
 
           {showHint && <HintBubble />}
-
-          <View style={styles.padWrap}>
-            <NumberPad
-              value={userAnswer}
-              onChange={setUserAnswer}
-              onSubmit={checkAnswer}
-              disabled={feedback === 'correct'}
-            />
-          </View>
         </ScrollView>
+
+        <View style={styles.padWrap}>
+          <NumberPad
+            value={userAnswer}
+            onChange={setUserAnswer}
+            onSubmit={checkAnswer}
+            disabled={feedback === 'correct'}
+          />
+        </View>
       </SafeAreaView>
     </ScreenBackground>
   );
@@ -228,7 +228,7 @@ const styles = StyleSheet.create({
   scoreText: {
     fontSize: TYPOGRAPHY.SIZES.subtitle,
     fontWeight: TYPOGRAPHY.WEIGHTS.bold,
-    color: COLORS.pathDeep,
+    color: COLORS.grassDeep,
   },
   mainCard: {
     marginBottom: SIZING.MARGIN.medium,
@@ -266,7 +266,7 @@ const styles = StyleSheet.create({
   operatorText: {
     fontSize: TYPOGRAPHY.SIZES.heading,
     fontWeight: TYPOGRAPHY.WEIGHTS.bold,
-    color: COLORS.pathDeep,
+    color: COLORS.grassDeep,
     marginHorizontal: SIZING.MARGIN.medium,
   },
   equationRow: {
@@ -314,7 +314,9 @@ const styles = StyleSheet.create({
   feedbackCorrect: { color: COLORS.successDeep },
   feedbackIncorrect: { color: COLORS.errorDeep },
   padWrap: {
-    marginTop: 'auto',
+    paddingHorizontal: SIZING.PADDING.large,
+    paddingTop: SIZING.PADDING.medium,
+    paddingBottom: SIZING.PADDING.medium,
   },
 });
 

--- a/src/screens/learning/StoryProblemsScreen.js
+++ b/src/screens/learning/StoryProblemsScreen.js
@@ -115,7 +115,7 @@ const StoryProblemsScreen = ({ navigation }) => {
 
   return (
     <ScreenBackground tint="lavender">
-      <SafeAreaView style={styles.safe}>
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right', 'bottom']}>
         <BackButton confirm onPress={() => navigation.goBack()} />
         <ScrollView
           style={styles.scroll}
@@ -172,24 +172,24 @@ const StoryProblemsScreen = ({ navigation }) => {
               {feedback === 'correct' ? `🎉 ${t('feedback.excellent')}` : `💭 ${t('feedback.almost')}`}
             </Text>
           )}
-
-          <View style={styles.padWrap}>
-            <NumberPad
-              value={userAnswer}
-              onChange={setUserAnswer}
-              onSubmit={checkAnswer}
-              disabled={feedback === 'correct'}
-            />
-            <Button
-              title={t('common.new_problem')}
-              onPress={skipQuestion}
-              variant="outline"
-              size="medium"
-              icon="🔄"
-              style={styles.skipButton}
-            />
-          </View>
         </ScrollView>
+
+        <View style={styles.padWrap}>
+          <NumberPad
+            value={userAnswer}
+            onChange={setUserAnswer}
+            onSubmit={checkAnswer}
+            disabled={feedback === 'correct'}
+          />
+          <Button
+            title={t('common.new_problem')}
+            onPress={skipQuestion}
+            variant="outline"
+            size="medium"
+            icon="🔄"
+            style={styles.skipButton}
+          />
+        </View>
       </SafeAreaView>
     </ScreenBackground>
   );
@@ -316,7 +316,9 @@ const styles = StyleSheet.create({
   feedbackCorrect: { color: COLORS.successDeep },
   feedbackIncorrect: { color: COLORS.errorDeep },
   padWrap: {
-    marginTop: SIZING.MARGIN.medium,
+    paddingHorizontal: SIZING.PADDING.large,
+    paddingTop: SIZING.PADDING.medium,
+    paddingBottom: SIZING.PADDING.medium,
   },
   skipButton: {
     marginTop: SIZING.MARGIN.medium,

--- a/src/screens/learning/SubtractionVisualScreen.js
+++ b/src/screens/learning/SubtractionVisualScreen.js
@@ -118,7 +118,7 @@ const SubtractionVisualScreen = ({ navigation }) => {
 
   return (
     <ScreenBackground tint="sunrise">
-      <SafeAreaView style={styles.safe}>
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right', 'bottom']}>
         <BackButton confirm onPress={() => navigation.goBack()} />
         <ScrollView
           style={styles.scroll}
@@ -175,16 +175,16 @@ const SubtractionVisualScreen = ({ navigation }) => {
           </Card>
 
           {showHint && <HintBubble />}
-
-          <View style={styles.padWrap}>
-            <NumberPad
-              value={userAnswer}
-              onChange={setUserAnswer}
-              onSubmit={checkAnswer}
-              disabled={feedback === 'correct'}
-            />
-          </View>
         </ScrollView>
+
+        <View style={styles.padWrap}>
+          <NumberPad
+            value={userAnswer}
+            onChange={setUserAnswer}
+            onSubmit={checkAnswer}
+            disabled={feedback === 'correct'}
+          />
+        </View>
       </SafeAreaView>
     </ScreenBackground>
   );
@@ -319,7 +319,9 @@ const styles = StyleSheet.create({
   feedbackCorrect: { color: COLORS.successDeep },
   feedbackIncorrect: { color: COLORS.errorDeep },
   padWrap: {
-    marginTop: 'auto',
+    paddingHorizontal: SIZING.PADDING.large,
+    paddingTop: SIZING.PADDING.medium,
+    paddingBottom: SIZING.PADDING.medium,
   },
 });
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -21,6 +21,9 @@ export const COLORS = {
   // Neutrals
   white: '#FFFFFF',
   overlay: 'rgba(255,255,255,0.94)',
+  // Neutral press-shadow used on controls that sit on varied tinted backgrounds
+  // (e.g. BackButton, PillAction) — tints-agnostic so it reads on any screen.
+  pressShadow: 'rgba(0,0,0,0.18)',
 
   // Pastel accents (kids-friendly palette)
   lightBlue: '#E3F4FD',
@@ -35,11 +38,25 @@ export const COLORS = {
   peach: '#FFE0C2',
   peachDeep: '#FFA86B',
 
+  // "Lip" colors — one step darker than *Deep, used as the bottom-border
+  // shadow on chunky plastic buttons (Button, TileButton, NumberPad, game
+  // option tiles). Keep these in sync with the *Deep family above.
+  skyLip: '#4FA6CE',
+  grassLip: '#3E9A40',
+  pathLip: '#C8770F',
+  softPurpleLip: '#8A5FB8',
+  warmYellowLip: '#C99A1F',
+  mintLip: '#3FA07F',
+  peachLip: '#E08848',
+
   // Screen background tints (soft pastels)
   bgSky: '#DEF2FC',
   bgMint: '#DFF7EC',
   bgSunrise: '#FFF4E0',
   bgLavender: '#F1E5FA',
+  bgTeal: '#D4F1EC',
+  bgRose: '#FDE0E4',
+  bgLemon: '#FFF8CC',
 };
 
 // Difficulty levels configuration
@@ -131,6 +148,19 @@ export const SIZING = {
   },
 };
 
+// Icon/emoji size ladder. Use these instead of raw pt values so mascot,
+// hero, and inline emoji sizes stay on the same rhythm across screens.
+//   hero       — signature character/moment (Welcome mascot, Progress tree)
+//   feature    — primary in-content mascot / hero emoji on a screen
+//   supporting — chip/stat emoji, object-count visuals
+//   inline     — section headers, list row icons
+export const ICON_SIZES = {
+  hero: 120,
+  feature: 64,
+  supporting: 40,
+  inline: 24,
+};
+
 // Typography
 // `tiny` is reserved for parent/meta text only (never a kid-facing label).
 // Kid-facing body text must use `body` (20pt) or above.
@@ -196,4 +226,5 @@ export const STORAGE_KEYS = {
   SETTINGS: '@app:settings',
   ACHIEVEMENTS: '@app:achievements',
   TREE_STATE: '@app:tree_state',
+  HAS_SEEN_WELCOME: '@app:has_seen_welcome',
 };


### PR DESCRIPTION
## Summary

Shaped by a `/design-critique` pass over every screen. Two themes:

1. **Onboarding friction** — welcome screen showed on every launch; main menu wasted vertical space.
2. **Design-system drift** — hardcoded hex colors bypassing tokens, background tints colliding across unrelated screens, menu tile colors not matching in-screen accent colors.

## What changed

### Onboarding
- **Main menu**: dropped the mascot+greeting header and shrunk tiles to a 3-col `size="small"` grid. Learn, Play, and Tree/Settings now fit on one screen without scrolling.
- **Welcome**: mascot 200→120pt (matches new `ICON_SIZES.hero`). Skips to Main Menu automatically on repeat launches via a `HAS_SEEN_WELCOME` AsyncStorage flag — first-time kids still meet Robot Logik; returning kids get zero taps to math.
- `startSession()` moved from Welcome to MainMenu so it still fires when Welcome is bypassed.

### Tokens
- New `ICON_SIZES` ladder: `hero: 120, feature: 64, supporting: 40, inline: 24`.
- 7 new `*Lip` shadow colors (`skyLip`, `grassLip`, `pathLip`, `softPurpleLip`, `warmYellowLip`, `mintLip`, `peachLip`) replace hardcoded hexes like `'#4FA6CE'` / `'#8A5FB8'` across TileButton, Button, NumberLabyrinth and LostNumbers option palettes.
- 3 new background tints (`bgTeal`, `bgRose`, `bgLemon`) so each game screen has a unique backdrop instead of colliding 3-way on lavender.
- Neutral `pressShadow` for controls sitting on varied tinted backgrounds.

### Color identity
Each feature now reads as one color end-to-end:
- **Addition**: operator + score → `grassDeep` (matches green menu tile).
- **FindPair**: card base + flipped-border + header value → `peachDeep` (matches peach menu tile). Tint: `sunrise` → `rose`.
- **LostNumbers**: yellow leads the option palette; current-missing ring → `pathDeep`. Tint: `lavender` → `lemon`.
- **Labyrinth**: tint `sky` → `teal` (sky was also used by Welcome/MainMenu).

### Layout
- Title pills removed from Progress and Settings — BackButton already provides wayfinding and the pills stole ~80pt of vertical space.
- `NumberPad` moved outside the `ScrollView` on Addition/Subtraction/Stories. Problem area scrolls independently; keypad is always reachable at the bottom.
- `BackButton` border: hardcoded `skyDeep` → neutral `pressShadow` so it reads on any screen tint.

## Test plan
- [ ] Cold-launch app on a fresh install — Welcome appears, mascot is hero-sized, "Let's Start" goes to Main Menu
- [ ] Force-quit and relaunch — skips straight to Main Menu (no Welcome flash)
- [ ] Main Menu — six tiles fit above "My Tree of Reason" / "Settings" without scrolling on common phone sizes
- [ ] Tap each tile — in-screen accent color matches the menu tile color:
  - [ ] Addition: green operator, green score
  - [ ] Subtraction: orange (unchanged)
  - [ ] Stories: purple (unchanged)
  - [ ] Labyrinth: sky blue doors on teal backdrop
  - [ ] FindPair: peach cards on rose backdrop
  - [ ] LostNumbers: yellow-led options on lemon backdrop
- [ ] Open Addition / Subtraction / Stories — NumberPad sits at the bottom of the screen and stays there while the problem area scrolls
- [ ] Open Progress / Settings — no redundant title pill; BackButton visible and usable
- [ ] Back button arrow reads clearly on every screen tint (mint, sunrise, lavender, teal, rose, lemon, sky)
- [ ] `git grep "#[0-9A-Fa-f]\{6\}"` — remaining hex literals live only in `constants.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)