### PR TITLE
fix: equalize tile heights and rework DifficultyPicker

### DIFF
--- a/src/components/common/DifficultyPicker.js
+++ b/src/components/common/DifficultyPicker.js
@@ -7,29 +7,59 @@ import BackButton from './BackButton';
 import TileButton from './TileButton';
 import { DIFFICULTY_LEVELS, COLORS, SIZING, TYPOGRAPHY, SHADOWS } from '../../utils/constants';
 
+// Hero background is driven by the module's palette so the picker reads as
+// "still in Addition" (green), "still in Find the Pair" (peach), etc.
+const HERO_PALETTES = {
+  sky:    { bg: COLORS.skyDeep,        text: COLORS.white },
+  grass:  { bg: COLORS.grassDeep,      text: COLORS.white },
+  path:   { bg: COLORS.path,           text: COLORS.white },
+  purple: { bg: COLORS.softPurpleDeep, text: COLORS.white },
+  mint:   { bg: COLORS.mintDeep,       text: COLORS.white },
+  yellow: { bg: COLORS.warmYellowDeep, text: COLORS.text  },
+  peach:  { bg: COLORS.peachDeep,      text: COLORS.white },
+};
+
 const LEVEL_META = {
-  easy:   { icon: '🌱', color: 'mint' },
-  medium: { icon: '🌿', color: 'yellow' },
-  hard:   { icon: '🌳', color: 'peach' },
+  easy:   { icon: '🌱', color: 'mint',   descKey: 'difficulty.easy_desc'   },
+  medium: { icon: '🌿', color: 'yellow', descKey: 'difficulty.medium_desc' },
+  hard:   { icon: '🌳', color: 'peach',  descKey: 'difficulty.hard_desc'   },
 };
 
 const DifficultyPicker = ({
   tint = 'sky',
+  color = 'sky',
   icon,
   title,
   subtitle,
   onSelect,
   onBack,
 }) => {
+  const hero = HERO_PALETTES[color] || HERO_PALETTES.sky;
+
   return (
     <ScreenBackground tint={tint}>
       <SafeAreaView style={styles.safe}>
         <BackButton onPress={onBack} />
         <View style={styles.container}>
-          <View style={styles.heroCard}>
+          <View style={[styles.heroBar, { backgroundColor: hero.bg }]}>
             {icon ? <Text style={styles.heroIcon}>{icon}</Text> : null}
-            <Text style={styles.title}>{title}</Text>
-            {subtitle ? <Text style={styles.subtitle}>{subtitle}</Text> : null}
+            <View style={styles.heroText}>
+              <Text
+                style={[styles.heroTitle, { color: hero.text }]}
+                numberOfLines={1}
+                adjustsFontSizeToFit
+              >
+                {title}
+              </Text>
+              {subtitle ? (
+                <Text
+                  style={[styles.heroSubtitle, { color: hero.text }]}
+                  numberOfLines={2}
+                >
+                  {subtitle}
+                </Text>
+              ) : null}
+            </View>
           </View>
 
           <Text style={styles.instruction}>{t('difficulty.choose_level')}</Text>
@@ -41,9 +71,10 @@ const DifficultyPicker = ({
                 <View key={key} style={styles.gridCell}>
                   <TileButton
                     title={t(`difficulty.${key}`)}
+                    subtitle={t(meta.descKey)}
                     icon={meta.icon}
                     color={meta.color}
-                    size="small"
+                    size="medium"
                     onPress={() => onSelect(key)}
                   />
                 </View>
@@ -60,32 +91,35 @@ const styles = StyleSheet.create({
   safe: { flex: 1 },
   container: {
     flex: 1,
-    justifyContent: 'center',
-    padding: SIZING.PADDING.large,
+    paddingHorizontal: SIZING.PADDING.large,
+    paddingTop: 96,
+    paddingBottom: SIZING.PADDING.large,
   },
-  heroCard: {
-    backgroundColor: COLORS.overlay,
-    borderRadius: SIZING.BORDER_RADIUS.xlarge,
-    padding: SIZING.PADDING.large,
+  heroBar: {
+    flexDirection: 'row',
     alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: SIZING.BORDER_RADIUS.large,
+    paddingVertical: SIZING.PADDING.medium,
+    paddingHorizontal: SIZING.PADDING.large,
     marginBottom: SIZING.MARGIN.large,
-    ...SHADOWS.card,
+    ...SHADOWS.soft,
   },
   heroIcon: {
-    fontSize: 64,
-    marginBottom: SIZING.MARGIN.small,
+    fontSize: 44,
+    marginRight: 14,
   },
-  title: {
-    fontSize: TYPOGRAPHY.SIZES.heading,
+  heroText: {
+    flexShrink: 1,
+  },
+  heroTitle: {
+    fontSize: TYPOGRAPHY.SIZES.title,
     fontWeight: TYPOGRAPHY.WEIGHTS.bold,
-    color: COLORS.text,
-    textAlign: 'center',
   },
-  subtitle: {
+  heroSubtitle: {
+    marginTop: 4,
     fontSize: TYPOGRAPHY.SIZES.body,
-    color: COLORS.textSoft,
-    textAlign: 'center',
-    marginTop: 6,
+    opacity: 0.9,
   },
   instruction: {
     fontSize: TYPOGRAPHY.SIZES.subtitle,

--- a/src/components/common/TileButton.js
+++ b/src/components/common/TileButton.js
@@ -45,11 +45,21 @@ const TileButton = ({
           ]}
         >
           {icon ? <Text style={styles[`icon_${size}`]}>{icon}</Text> : null}
-          <Text style={[styles[`title_${size}`], { color: p.text }]} numberOfLines={2}>
+          <Text
+            style={[styles[`title_${size}`], { color: p.text }]}
+            numberOfLines={2}
+            adjustsFontSizeToFit
+            minimumFontScale={0.7}
+          >
             {title}
           </Text>
           {subtitle ? (
-            <Text style={[styles.subtitle, { color: p.text }]} numberOfLines={1}>
+            <Text
+              style={[styles.subtitle, { color: p.text }]}
+              numberOfLines={1}
+              adjustsFontSizeToFit
+              minimumFontScale={0.75}
+            >
               {subtitle}
             </Text>
           ) : null}
@@ -72,15 +82,15 @@ const styles = StyleSheet.create({
   },
   face_small: {
     paddingVertical: SIZING.PADDING.medium,
-    minHeight: 90,
+    height: 120,
   },
   face_medium: {
     paddingVertical: SIZING.PADDING.large,
-    minHeight: 130,
+    height: 150,
   },
   face_large: {
     paddingVertical: SIZING.PADDING.xlarge,
-    minHeight: 170,
+    height: 190,
   },
   icon_small: { fontSize: 36, marginBottom: 6 },
   icon_medium: { fontSize: 48, marginBottom: 10 },
@@ -101,9 +111,10 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   subtitle: {
-    marginTop: 4,
-    fontSize: TYPOGRAPHY.SIZES.small,
-    opacity: 0.9,
+    marginTop: 6,
+    fontSize: TYPOGRAPHY.SIZES.body,
+    fontWeight: TYPOGRAPHY.WEIGHTS.bold,
+    opacity: 0.95,
     textAlign: 'center',
   },
 });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -32,12 +32,12 @@
     "settings": "Settings"
   },
   "difficulty": {
-    "easy": "Easy-Peasy",
-    "easy_desc": "Numbers 0-10",
+    "easy": "Easy‑Peasy",
+    "easy_desc": "0‑10",
     "medium": "I Can Do Math",
-    "medium_desc": "Numbers 0-20",
+    "medium_desc": "0‑20",
     "hard": "Math Pro",
-    "hard_desc": "Numbers 0-50",
+    "hard_desc": "0‑50",
     "choose_level": "Choose Your Level"
   },
   "learning": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -32,12 +32,12 @@
     "settings": "Configuración"
   },
   "difficulty": {
-    "easy": "Fácil-fácil",
-    "easy_desc": "Números 0-10",
+    "easy": "Fácil‑fácil",
+    "easy_desc": "0‑10",
     "medium": "Puedo con las Mates",
-    "medium_desc": "Números 0-20",
+    "medium_desc": "0‑20",
     "hard": "Profesional de Mates",
-    "hard_desc": "Números 0-50",
+    "hard_desc": "0‑50",
     "choose_level": "Elige tu Nivel"
   },
   "learning": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -32,12 +32,12 @@
     "settings": "Настройки"
   },
   "difficulty": {
-    "easy": "Легко-легко",
-    "easy_desc": "Числа 0-10",
+    "easy": "Легко‑легко",
+    "easy_desc": "0‑10",
     "medium": "Я умею считать",
-    "medium_desc": "Числа 0-20",
-    "hard": "Математик-профи",
-    "hard_desc": "Числа 0-50",
+    "medium_desc": "0‑20",
+    "hard": "Математик‑профи",
+    "hard_desc": "0‑50",
     "choose_level": "Выбери свой уровень"
   },
   "learning": {

--- a/src/screens/MainMenuScreen.js
+++ b/src/screens/MainMenuScreen.js
@@ -105,7 +105,14 @@ const PillAction = ({ icon, label, color, onPress }) => (
         ]}
       >
         <Text style={styles.pillIcon}>{icon}</Text>
-        <Text style={styles.pillLabel}>{label}</Text>
+        <Text
+          style={styles.pillLabel}
+          numberOfLines={2}
+          adjustsFontSizeToFit
+          minimumFontScale={0.85}
+        >
+          {label}
+        </Text>
       </View>
     )}
   </Pressable>
@@ -157,18 +164,19 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    paddingVertical: SIZING.PADDING.medium,
+    paddingVertical: SIZING.PADDING.small,
     paddingHorizontal: SIZING.PADDING.medium,
     borderRadius: SIZING.BORDER_RADIUS.pill,
     borderBottomWidth: 4,
     borderBottomColor: 'rgba(0,0,0,0.2)',
-    minHeight: SIZING.SECONDARY_TARGET,
+    height: 76,
   },
   pillIcon: {
     fontSize: 28,
     marginRight: 10,
   },
   pillLabel: {
+    flexShrink: 1,
     color: COLORS.white,
     fontWeight: TYPOGRAPHY.WEIGHTS.bold,
     fontSize: TYPOGRAPHY.SIZES.body,

--- a/src/screens/games/FindPairScreen.js
+++ b/src/screens/games/FindPairScreen.js
@@ -118,6 +118,7 @@ const FindPairScreen = ({ navigation }) => {
     return (
       <DifficultyPicker
         tint="rose"
+        color="peach"
         icon="🎴"
         title={t('games.find_pair')}
         subtitle={t('games.match_cards')}

--- a/src/screens/games/LostNumbersScreen.js
+++ b/src/screens/games/LostNumbersScreen.js
@@ -107,6 +107,7 @@ const LostNumbersScreen = ({ navigation }) => {
     return (
       <DifficultyPicker
         tint="lemon"
+        color="yellow"
         icon="🔢"
         title={t('games.lost_numbers')}
         subtitle={t('games.complete_sequence')}

--- a/src/screens/games/NumberLabyrinthScreen.js
+++ b/src/screens/games/NumberLabyrinthScreen.js
@@ -79,6 +79,7 @@ const NumberLabyrinthScreen = ({ navigation }) => {
     return (
       <DifficultyPicker
         tint="teal"
+        color="sky"
         icon="🧩"
         title={t('games.number_labyrinth')}
         subtitle={t('games.help_robot')}

--- a/src/screens/learning/AdditionVisualScreen.js
+++ b/src/screens/learning/AdditionVisualScreen.js
@@ -99,6 +99,7 @@ const AdditionVisualScreen = ({ navigation }) => {
     return (
       <DifficultyPicker
         tint="mint"
+        color="grass"
         icon="➕"
         title={t('learning.addition')}
         onSelect={selectDifficulty}

--- a/src/screens/learning/StoryProblemsScreen.js
+++ b/src/screens/learning/StoryProblemsScreen.js
@@ -99,6 +99,7 @@ const StoryProblemsScreen = ({ navigation }) => {
     return (
       <DifficultyPicker
         tint="lavender"
+        color="purple"
         icon="📖"
         title={t('learning.story_problems')}
         onSelect={selectDifficulty}

--- a/src/screens/learning/SubtractionVisualScreen.js
+++ b/src/screens/learning/SubtractionVisualScreen.js
@@ -102,6 +102,7 @@ const SubtractionVisualScreen = ({ navigation }) => {
     return (
       <DifficultyPicker
         tint="sunrise"
+        color="path"
         icon="➖"
         title={t('learning.subtraction')}
         onSelect={selectDifficulty}


### PR DESCRIPTION
## Summary

- **Equal tile heights on Main Menu** — `TileButton` now uses a fixed height (was `minHeight`), so tiles in a row align regardless of how the title wraps. Long single words (`Subtraction`, `Easy‑Peasy`) use `adjustsFontSizeToFit` with a 0.7 floor so they shrink instead of character-breaking mid-word.
- **Rework DifficultyPicker** — the oversized white hero card that dominated the screen is replaced with a compact colored header bar that matches the module's Main Menu tile color (Addition → green, Subtraction → orange, etc.). Level tiles bumped from `small` to `medium` and now show the numeric range (`0‑10`, `0‑20`, `0‑50`) as a subtitle so kids can self-select by what they recognize. Content anchors below the back button instead of vertically centering, removing the empty gap at top.
- **Main Menu bottom pills** — fixed height, 2-line label with font scaling so `My Tree of Reason` and `Settings` pills match height.
- **Non-breaking hyphens in locales** — compound difficulty labels (`Easy‑Peasy`, `Математик‑профи`, `Легко‑легко`, `Fácil‑fácil`) and number ranges use `U+2011` so they wrap as single units. Range descriptions shortened to just the numbers (`0‑10`) for tighter tile layout.

## Why

Design critique turned up three real problems visible on the emulator:
1. Tiles in the same row rendered at different heights because title wrap lines varied (1 vs 2).
2. The difficulty picker's hero was a huge white card with a grey plus icon — visually dominated the screen and inverted hierarchy: the primary decision ("pick a level") was demoted.
3. `Easy-Peasy` broke as `Easy-Pe / asy` at the regular hyphen, violating kid-UX rule U9 (affordance without reading).

## Test plan

- [ ] Main Menu: all six tiles in the Learn/Play rows are equal height
- [ ] Main Menu: `My Tree of Reason` and `Settings` pills are equal height and fully readable
- [ ] DifficultyPicker (Addition): green header bar matches Main Menu Addition tile, level tiles show `0‑10`/`0‑20`/`0‑50` subtitles
- [ ] DifficultyPicker (all 6 modules): hero color matches the module's Main Menu tile
- [ ] Non-breaking hyphen verified for `Easy‑Peasy` in EN, `Легко‑легко`/`Математик‑профи` in RU, `Fácil‑fácil` in ES
- [ ] Back button still functional on all DifficultyPicker screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)